### PR TITLE
Use numNodes instead of num_nodes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ spec:
   version: "5"
   size: db-s-2vcpu-4gb
   region: sfo2
-  num_nodes: 2
+  numNodes: 2
   tags:
   - test
   - doop


### PR DESCRIPTION
This just reflects [an update to the example](https://github.com/digitalocean/do-operator/commit/b9914049b2f708190b13af2b368875afeda74646) in the readme. 

Without this fix I was greeted with this beauty. 

```
POST https://api.digitalocean.com/v2/databases: 422 (request \"[...]\") invalid node count
```