### PR TITLE
Add GitHub actions to test and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      tag:
+        # Friendly description to be shown in the UI instead of 'name'
+        description: 'tag and release to create'
+        # Input has to be provided for the workflow to run
+        required: true
+env:
+  GITHUB_ENV: ".env"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.19
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Login to dockerhub to push the image
+        run: echo "${{ secrets.DockerHubToken }}" | docker login --username ${DOCKER_USER} --password-stdin
+        env:
+          DOCKER_USER: ${{ secrets.DockerHubUser }}
+      - name: Build and push docker image
+        run: make docker-build docker-push
+        env:
+          IMG_TAG: ${{ github.event.inputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+env:
+  GITHUB_ENV: ".env"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.19
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Install kubebuilder
+        uses: RyanSiu1995/kubebuilder-action@v1.2
+        with:
+          version: 3.5.0
+      - name: Run make test
+        run: make test


### PR DESCRIPTION
Two actions workflows:

* `test` - Run tests on merges to main and PRs.
* `release` - Push docker images when tags are created.
