### PR TITLE
Fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,9 @@ jobs:
         env:
           IMG_TAG: ${{ github.event.inputs.tag }}
       - name: Build and commit manifests
-        run: make release-manifests
+        run: |
+          echo 'access-token=<your api token here>' > config/manager/do-api-token.env
+          make release-manifests
         env:
           IMG_TAG: ${{ github.event.inputs.tag }}
       - name: Commit manifests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,5 @@ jobs:
           go-version: ^1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
-      - name: Install kubebuilder
-        uses: RyanSiu1995/kubebuilder-action@v1.2
-        with:
-          version: 3.5.0
       - name: Run make test
         run: make test


### PR DESCRIPTION
We need to put in a placeholder API token to generate manifests.

While we're here, stop installing kubebuilder in the test workflow. The makefile knows how to install controller-gen and that's all it needs.
