### PR TITLE
Run the release workflow on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,8 @@
 name: release
 on:
-  workflow_dispatch:
-    # Inputs the workflow accepts.
-    inputs:
-      tag:
-        # Friendly description to be shown in the UI instead of 'name'
-        description: 'tag and release to create'
-        # Input has to be provided for the workflow to run
-        required: true
+  push:
+    tags:
+      - v**
 env:
   GITHUB_ENV: ".env"
 jobs:
@@ -20,37 +15,13 @@ jobs:
           go-version: ^1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+      - name: Validate that the release manifest exists
+        run: |
+          [[ -f "releases/do-operator-$(git describe --tags).yaml" ]] || false
       - name: Login to dockerhub to push the image
         run: echo "${{ secrets.DockerHubToken }}" | docker login --username ${DOCKER_USER} --password-stdin
         env:
           DOCKER_USER: ${{ secrets.DockerHubUser }}
       - name: Build and push docker image
-        run: make docker-build docker-push
-        env:
-          IMG_TAG: ${{ github.event.inputs.tag }}
-      - name: Build and commit manifests
         run: |
-          echo 'access-token=<your api token here>' > config/manager/do-api-token.env
-          make release-manifests
-        env:
-          IMG_TAG: ${{ github.event.inputs.tag }}
-      - name: Commit manifests
-        uses: EndBug/add-and-commit@998652d28d7702d095d40f52ae42982a80ae8c7d
-        with:
-          message: "Create release manifests for ${{ github.event.inputs.tag }}"
-          add: "releases/"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: find target commit to tag
-        run: |
-          sha=$(git rev-parse HEAD)
-          echo "TARGET_SHA=$sha" >> $GITHUB_ENV
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          commitish: ${{ env.TARGET_SHA }}
-          tag_name: ${{ github.event.inputs.tag }}
-          release_name: ${{ github.event.inputs.tag }}
+          make docker-build docker-push IMG_TAG="$(git describe --tags)"


### PR DESCRIPTION
The previous release workflow was manually triggered, and would create the release manifests. That's nice in theory, but there's no good way to let Actions push to a protected branch.

Run the release manifest when a tag is created instead, and have it validate that the release manifests exist before pushing.
