### PR TITLE
Fix release manifest, bump to v0.1.3

### DIFF
--- a/releases/do-operator-v0.1.3.yaml
+++ b/releases/do-operator-v0.1.3.yaml
@@ -701,7 +701,7 @@ spec:
             secretKeyRef:
               key: access-token
               name: do-operator-do-api-token
-        image: docker.io/digitalocean/do-operator:0.1.2
+        image: docker.io/digitalocean/do-operator:v0.1.3
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Forgot the `v` in the version tag, oops.
