### PR TITLE
Set the user-agent for godo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ COPY controllers/ controllers/
 COPY extgodo/ extgodo/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+ARG LDFLAGS
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+LDFLAGS ?= -X main.version=$(IMG_TAG)
+
 .PHONY: all
 all: build
 
@@ -63,7 +65,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -71,7 +73,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --build-arg LDFLAGS="$(LDFLAGS)" -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
Show that requests are coming from the do-operator by setting a custom user-agent for godo. Set the version during the build process so we can include it in the user-agent string.
