### PR TITLE
bug fix: missing age column for databasecluster

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -75,6 +75,7 @@ type DatabaseClusterStatus struct {
 //+kubebuilder:subresource:status
 
 // DatabaseCluster is the Schema for the databaseclusters API
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Engine",type=string,JSONPath=`.spec.engine`
 // +kubebuilder:printcolumn:name="Cluster name",type=string,JSONPath=`.spec.name`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`

--- a/config/crd/bases/databases.digitalocean.com_databaseclusters.yaml
+++ b/config/crd/bases/databases.digitalocean.com_databaseclusters.yaml
@@ -16,6 +16,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .spec.engine
       name: Engine
       type: string


### PR DESCRIPTION
When you add in additional columns (#15) you lose the default `Age` column and so you have to specify it again

Result:
```
$ k -n my-application get databaseclusters
NAME        AGE    ENGINE   CLUSTER NAME   STATUS
my-app-db   164m   mysql    my-app-db      online
```