### PR TITLE
Add CA cert information to the credentials secret

### DIFF
--- a/controllers/credentials_secret.go
+++ b/controllers/credentials_secret.go
@@ -7,7 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func credentialsSecretForDefaultDBUser(owner client.Object, db *godo.Database) *corev1.Secret {
+func credentialsSecretForDefaultDBUser(owner client.Object, db *godo.Database, ca *godo.DatabaseCA) *corev1.Secret {
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -27,6 +27,10 @@ func credentialsSecretForDefaultDBUser(owner client.Object, db *godo.Database) *
 	// We assume connection is non-nil, but private connection could be nil.
 	if db.PrivateConnection != nil {
 		secret.StringData["private_uri"] = db.PrivateConnection.URI
+	}
+
+	if ca != nil && len(ca.Certificate) > 0 {
+		secret.StringData["ca.crt"] = string(ca.Certificate)
 	}
 
 	return secret

--- a/fakegodo/databases.go
+++ b/fakegodo/databases.go
@@ -60,7 +60,10 @@ func (f *FakeDatabasesService) Get(_ context.Context, dbUUID string) (*godo.Data
 
 // GetCA ...
 func (f *FakeDatabasesService) GetCA(_ context.Context, _ string) (*godo.DatabaseCA, *godo.Response, error) {
-	panic("not implemented")
+	ca := godo.DatabaseCA{
+		Certificate: []byte{01, 02, 03, 04, 05},
+	}
+	return &ca, okResponse, nil
 }
 
 // Create ...


### PR DESCRIPTION
As the self-signed CA cert is required to properly secure some database connections, include the cert information in the credentials secret.

Addresses https://github.com/digitalocean/do-operator/issues/40